### PR TITLE
Various housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+.phpcs.xml
+phpcs.xml

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -2,44 +2,70 @@
 <ruleset name="Adminbar Link Comments to Pending">
 	<description>The code standard for Adminbar Link Comments to Pending is WordPress.</description>
 
-	<!-- Pass some flags to PHPCS:
-		 p flag: Show progress of the run.
-		 s flag: Show sniff codes in all reports.
-		 v flag: Print verbose output.
-		 n flag: Do not print warnings.
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
 	-->
-	<arg value="ps"/>
 
-	<!-- Only check the PHP files. -->
+	<!-- Scan all files. -->
+	<file>./adminbar-link-comments-to-pending.php</file>
+
+	<!-- Only check PHP files. -->
 	<arg name="extensions" value="php"/>
 
-	<!-- Check all files in this directory and the directories below it. -->
-	<file>./adminbar-link-comments-to-pending.php</file>
-	
-	<!-- Set minimum supported WP version for all sniffs which use it. -->
-	<config name="minimum_supported_wp_version" value="3.3"/>
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="sp"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WordPress and the PHPCompatibility RULESETS
+	#############################################################################
+	-->
+
 
 	<!-- ##### PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-"/>
 	<rule ref="PHPCompatibility"/>
 
 	<!-- ##### WordPress sniffs ##### -->
+	<!-- Set minimum supported WP version for all sniffs which use it. -->
+	<config name="minimum_supported_wp_version" value="3.3"/>
+
 	<rule ref="WordPress">
 		<!-- No need to lint the PHP, this is done in a separate task in the travis script. -->
 		<exclude name="Generic.PHP.Syntax"/>
 	</rule>
 
+
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
+
 	<!-- Enable verification that all I18n calls use the correct text-domain. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="adminbar-link-comments-to-pending"/>
+			<property name="text_domain" type="array">
+				<element value="adminbar-link-comments-to-pending"/>
+			</property>
 		</properties>
 	</rule>
 
 	<!-- Enable verification that everything in the global namespace is prefixed. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
-			<property name="prefixes" type="array" value="adminbar_comments_link" />
+			<property name="prefixes" type="array">
+				<element value="adminbar_comments_link"/>
+			</property>
 		</properties>
 	</rule>
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_script:
 # All commands must exit with code 0 on success. Anything else is considered failure.
 script:
     # Search for PHP syntax errors.
-    - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+    - find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
     # Check code against the WordPress Coding Standards and for PHP cross-version compatibility.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://github.com/wimg/phpcompatibility

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 # Travis CI (MIT License) configuration file
 # @link https://travis-ci.org/
 
-# Use new container based environment
-sudo: false
-
-dist: trusty
+os: linux
 
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
@@ -12,19 +9,18 @@ language: php
 
 # Declare versions of PHP to use. Use one decimal max.
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
-  - 7.2
   - nightly
 
-matrix:
+jobs:
   fast_finish: true
 
   include:
-    - php: '7.1'
+    - php: '7.4'
       env: SNIFF=1
+    - php: '5.4'
+      dist: trusty
     - php: '5.3'
       dist: precise
     - php: '5.2'
@@ -36,32 +32,18 @@ matrix:
 before_script:
     # Speed up build time by disabling Xdebug when its not needed.
     - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-    # Set up temporary paths.
-    - export PHPCS_DIR=/tmp/phpcs
-    - export WPCS_DIR=/tmp/wpcs
-    - export PHPCOMPAT_DIR=/tmp/phpcompatibility
-    # Install CodeSniffer for WordPress Coding Standards checks.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
-    # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
-    # Install PHP Compatibility sniffs.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
-    # Set install path for PHPCS sniffs.
-    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
-    # After CodeSniffer install you should refresh your path.
-    - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+
+    # Install dependencies.
+    - |
+      if [[ "$SNIFF" == "1" ]]; then
+        composer install --no-suggest --no-interaction
+      fi
 
 # Run test script commands.
 # All commands must exit with code 0 on success. Anything else is considered failure.
 script:
     # Search for PHP syntax errors.
     - find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    # Check code against the WordPress Coding Standards and for PHP cross-version compatibility.
-    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
-    # @link http://github.com/wimg/phpcompatibility
-    # @link http://pear.php.net/package/PHP_CodeSniffer/
-    # Uses a custom ruleset based on WordPress. This ruleset is automatically
-    # picked up by PHPCS as it's named `phpcs.xml(.dist)`.
-    # Only fails the build on errors, not warnings, but still show warnings in the output.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --report-summary --report-source --report-full --runtime-set ignore_warnings_on_exit 1; fi
+
+    # Check code for style and cross-version compatibility issues.
+    - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpcs; fi

--- a/adminbar-link-comments-to-pending.php
+++ b/adminbar-link-comments-to-pending.php
@@ -7,7 +7,7 @@
  * @link        https://github.com/jrfnl/WP-adminbar-comments-to-pending
  * @version     1.0.1
  *
- * @copyright   2013-2018 Juliette Reinders Folmer
+ * @copyright   2013-2020 Juliette Reinders Folmer
  * @license     http://creativecommons.org/licenses/GPL/2.0/ GNU General Public License, version 2 or higher
  *
  * @wordpress-plugin
@@ -17,7 +17,7 @@
  * Version:     1.0.1
  * Author:      Juliette Reinders Folmer
  * Author URI:  http://www.adviesenzo.nl/
- * Copyright:   2013-2018 Juliette Reinders Folmer
+ * Copyright:   2013-2020 Juliette Reinders Folmer
  */
 
 // Avoid direct calls to this file.
@@ -32,6 +32,8 @@ if ( ! function_exists( 'adminbar_comments_link_to_pending' ) ) {
 	 * Change the comments link in the admin bar to go straight to the moderation queue.
 	 *
 	 * @param object $wp_admin_bar The admin bar object. Gets passed by reference.
+	 *
+	 * @return void
 	 */
 	function adminbar_comments_link_to_pending( $wp_admin_bar ) {
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name" : "jrfnl/adminbar-link-comments-to-pending",
+    "description" : "WordPress plugin which changes the link from the Adminbar comments bubble to go straight to the 'Pending' comments queue.",
+    "keywords"   : ["wordpress", "plugin" ],
+    "type"       : "wordpress-plugin",
+    "license"    : "GPL-2.0-or-later",
+    "authors"    : [
+        {
+            "name"    : "Juliette Reinders Folmer",
+            "homepage": "https://github.com/jrfnl"
+        }
+    ],
+    "support"    : {
+        "issues": "https://github.com/jrfnl/WP-adminbar-comments-to-pending/issues",
+        "source": "https://github.com/jrfnl/WP-adminbar-comments-to-pending"
+    },
+    "require": {
+        "php" : ">=5.2"
+    },
+    "require-dev": {
+        "wp-coding-standards/wpcs": "^2.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7"
+    },
+    "minimum-stability" : "RC",
+    "prefer-stable": true
+}

--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@ Requires at least: 3.3
 Tested up to: 4.9
 Stable tag: 1.0.1
 License: GPLv2
+Requires PHP: 5.2.6
 
 Changes the link from the Adminbar comments bubble to go straight to the 'Pending' comments queue.
 


### PR DESCRIPTION
### Add composer configuration

Includes:
* adding a `.gitignore` file to prevent the `composer.lock` file from being committed.
* excluding the `vendor` directory from PHP linting.

### Travis: simplify and update the script

* Use Composer to install dependencies.
* Update the PHP version matrix. No need to lint on every version, select versions should cover this well enough.
* Use the Travis default distro, currently `xenial` instead of setting a distro explicitly.
* Sets the distro for low PHP versions explicitly to `trusty`.
* Makes the expected OS explicit (linux).
* Updates the `matrix` key to `jobs`, which is the canonical for which `matrix` is an alias.
* Removed `sudo: false` - this hasn't been supported for over a year now.

### CS: update the ruleset & document it

### Plugin: update copyright years and docs

### Readme: annotate minimum PHP version supported
